### PR TITLE
add: template sheet links/wiki setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,13 @@ and templates within the project managed issues board.
 
 To start contributing:
 
-- Read the [contributing.md](https://github.com/ProfessionalLinuxUsersGroup/lac/blob/main/src/contributing.md) markdown
 - Understand the repository objectives
+- Read the [contributing.md](https://github.com/ProfessionalLinuxUsersGroup/lac/blob/main/src/contributing.md) markdown
+- Look over the [template pages wiki](https://github.com/ProfessionalLinuxUsersGroup/lac/wiki), or directly here:
+  - Pages: [intro](https://github.com/ProfessionalLinuxUsersGroup/lac/blob/main/ref/intro.md),
+    [bonus](https://github.com/ProfessionalLinuxUsersGroup/lac/blob/main/ref/ub.md),
+    [lab](https://github.com/ProfessionalLinuxUsersGroup/lac/blob/main/ref/ulab.md),
+    [worksheet](https://github.com/ProfessionalLinuxUsersGroup/lac/blob/main/ref/uws.md)
 - Request to be assigned a task within the repo [Issues](https://github.com/ProfessionalLinuxUsersGroup/lac/issues) tab
 - Fork this repository and create a development branch for eventual pull requests
 - Strictly adhere to contemporary GitHub contribution decorum to facilitate the version control process

--- a/ref/intro.md
+++ b/ref/intro.md
@@ -55,6 +55,7 @@ etc..
 (Any important terms relating to the unit)
 
 Term 1:
+
 Term 2:
 
 etc..

--- a/ref/ulab.md
+++ b/ref/ulab.md
@@ -21,7 +21,9 @@ laboris nisi ut aliquip ex ea commodo consequat.
 ### Resources / Important Links
 
 [Link Template](example.org)
+
 [Link Template](example.org)
+
 [Link Template](example.org)
 
 ### Required Materials
@@ -36,6 +38,7 @@ laboris nisi ut aliquip ex ea commodo consequat.
 (This will be transposed from the lab provided by Scott Champine)
 
 Step 1:
+
 Step 2:
 
 Code block:
@@ -49,6 +52,7 @@ etc..
 (This will be transposed from the lab provided by Scott Champine)
 
 Step 1:
+
 Step 2:
 
 Code block:

--- a/ref/uws.md
+++ b/ref/uws.md
@@ -21,7 +21,9 @@ laboris nisi ut aliquip ex ea commodo consequat.
 ### Resources / Important Links
 
 [Link Template](example.org)
+
 [Link Template](example.org)
+
 [Link Template](example.org)
 
 ### Unit # Recording
@@ -66,6 +68,7 @@ laboris nisi ut aliquip ex ea commodo consequat.
 (This will be transposed from the lab provided by Scott Champine)
 
 Term 1:
+
 Term 2:
 
 etc..

--- a/src/intro.md
+++ b/src/intro.md
@@ -9,7 +9,7 @@ Welcome to the ProLUG Enterprise Linux System Administration Course Book.
 
 ## This Book
 
-Contains all materials pertaining to the course including links to external resources. It has been put together with care by a number of ProLUG group members referencing original instructional materials produce by Scott Champine (Het Tanis). The content is version controlled with Git and stored - [Link to Repository](https://https://github.com/ProfessionalLinuxUsersGroup/lac/)
+Contains all materials pertaining to the course including links to external resources. It has been put together with care by a number of ProLUG group members referencing original instructional materials produce by Scott Champine (Het Tanis). The content is version controlled with Git and stored - [Link to Repository](https://github.com/ProfessionalLinuxUsersGroup/lac/)
 Furthermore, the book has been built with mdbook for ease of navigation. Be sure to try the search functionality.
 
 ## This Course


### PR DESCRIPTION
fix: formatting

fix: spacing

closes #129

Cleanup for the wiki pages. The links go directly to md pages. Wiki will need to be cleaned up and formatted later.