### PR TITLE
refactor: Optimize github action to reduce build time by utilizing caching

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -32,16 +32,47 @@ jobs:
       MDBOOK_VERSION: 0.4.36
     steps:
       - uses: actions/checkout@v4
+
+      # Install rust with GitHub's 'setup-rs' action (most recent stable version)
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable  # Or specify a version
+          override: true     # ensure this version is used globally in the workflow
+          components: cargo
+
+      # Cache rust crates (mdbook dependencies) so reinstalls don't take long
+      - name: Cache the cargo registry and build artifacts
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-${{ runner.os }}-
+
+      # Cache the mdbook binary so we don't need to install it every time
+      - name: Cache mdbook binary
+        id: cache-mdbook
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/bin/mdbook
+          key: mdbook-${{ runner.os }}-${{ env.MDBOOK_VERSION }}
+          restore-keys: mdbook-${{ runner.os }}-
+
+      # Install mdbook if it's not cached
       - name: Install mdBook
-        run: |
-          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
-          rustup update
-          cargo install --version ${MDBOOK_VERSION} mdbook
+        if: steps.cache-mdbook.outputs.cache-hit != 'true'
+        run: cargo install --version ${MDBOOK_VERSION} mdbook
+
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
+
       - name: Build with mdBook
         run: mdbook build
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
This change utilized caching to reduce build time.
The first build will take the same amount of time (averages just over 2 minutes). All of the project's dependencies will be cached for future use, which will prevent downloading and compiling `mdbook` and all its dependencies on each build.  

This change also uses the `setup-rs/toolchain@v1` to install Rust, a GitHub Action for `rustup` commands. The repository can be found [here](https://github.com/actions-rs/toolchain) (it is archived but still fully functional).  

These changes were tested on my fork with great results:
![image](https://github.com/user-attachments/assets/ca7bacc9-4315-41f0-9158-64f0a0d54c79)


The first build took 2 minutes and 17 seconds. After caching, the next build took 43 seconds, cutting off 93 seconds and improving build and deployment speed by about 69% (nice).