### PR TITLE
feat: add ability to requests changes based on document from site

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -10,4 +10,5 @@ default-theme = "navy"
 preferred-dark-theme = "navy"
 no-section-label = true
 git-repository-url = "https://github.com/ProfessionalLinuxUsersGroup/lac"
+edit-url-template = "https://github.com/ProfessionalLinuxUsersGroup/lac/edit/main/{path}"
 git-repository-icon = "fa-github"


### PR DESCRIPTION
By clicking the edit icon at the top right of a page a user will either be redirected to a github edit and commit landing page for the specific page it was clicked in or be directed to the fork repo process and facilitate the editing and committing workflow from there.

![image](https://github.com/user-attachments/assets/6bcc4de1-4670-4097-a87e-c0a68ab0c0f6)

Adds small icon next to the print and github icons.

![image](https://github.com/user-attachments/assets/9c6b1fb6-71e2-4193-bbbb-81b77f3374ab)

![image](https://github.com/user-attachments/assets/6a9d7a45-1a11-454d-a2c1-83e99aead3de)

Seems useful, would love to hear feedback