### PR TITLE
fix: Handle mdbook version changes gracefully

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -64,10 +64,10 @@ jobs:
           key: mdbook-${{ runner.os }}-${{ env.MDBOOK_VERSION }}
           restore-keys: mdbook-${{ runner.os }}-
 
-      # Install mdbook if it's not cached
+      # Install correct version of mdbook if it's not cached
       - name: Install mdBook
         if: steps.cache-mdbook.outputs.cache-hit != 'true'
-        run: cargo install --version ${MDBOOK_VERSION} mdbook
+        run: cargo install --version ${MDBOOK_VERSION} mdbook --force
 
       - name: Setup Pages
         id: pages


### PR DESCRIPTION
When the mdBook version is updated in the yaml file, the cache was (correctly) not getting a hit, but there was a build error. If the mdBook binary was previously cached, it would not allow a new install without the `--force` option. 
