### PR TITLE
chore:first pass replacing special characters in codeblocks

### DIFF
--- a/src/u1lab.md
+++ b/src/u1lab.md
@@ -73,7 +73,7 @@ It is recommended that you type these commands and do not copy and paste them. W
 # Creating empty files with touch
 touch fruits.txt
 
-ls –l fruits.txt
+ls -l fruits.txt
 # You will see that fruits.txt exists and is a 0 length (bytes) file
 
 -rw-r--r--. 1 root root 0 Jun 22 07:59 fruits.txt
@@ -82,9 +82,9 @@ ls –l fruits.txt
 # you’ve ever used tiered storage think about access times and how to keep data
 # hot/warm/cold. If you haven’t just look around for a bit.
 
-rm –rf fruits.txt
+rm -rf fruits.txt
 
-ls –l fruits.txt
+ls -l fruits.txt
 # You will see that fruits.txt is gone.
 ```
 
@@ -113,8 +113,8 @@ with >>, we never > over those types of files.
 ```bash
 # It is highly recommended the user read vimtutor. To get vimtutor follow
 # these steps:
-sudo –i
-yum –y install vim
+sudo -i
+yum -y install vim
 vimtutor
 
 # There are about 36 short labs to show a user how to get around inside of vi.
@@ -170,7 +170,7 @@ cat fruits.txt | grep APPLE
 # word apple at the beginning of the line.
 
 # If you can’t, here’s the the answer. Try it:
-cat fruits.txt | grep –i "^apple"
+cat fruits.txt | grep -i "^apple"
 ```
 
 Can you figure out why that worked? What do you think the ^ does?
@@ -190,7 +190,7 @@ cat fruits.txt
 # your file do anything to your original data? So let’s sort our data again
 # and figure out what this command does differently
 
-sort –k 2 fruits.txt
+sort -k 2 fruits.txt
 
 # You can of course man sort to figure it out, but –k refers to the “key” and
 # can be useful for sorting by a specific column
@@ -200,7 +200,7 @@ sort –k 2 fruits.txt
 # here’s an answer:
 
 sort fruits.txt > sort_by_alphabetical.txt
-sort –k 2 fruits.txt > sort_by_price.txt
+sort -k 2 fruits.txt > sort_by_price.txt
 
 # Cat both of those files out and verify their output
 ```
@@ -209,18 +209,18 @@ sort –k 2 fruits.txt > sort_by_price.txt
 
 ```bash
 # Consider the command
-ps –aux
+ps -aux
 
 # But that’s too long to probably see everything, so let’s use a command
 # to filter just the top few lines
-ps –aux | head
+ps -aux | head
 
 # So now you can see the actual fields (keys) across the top that we could sort by
 
 USER PID %CPU %MEM VSZ RSS TTY STAT START TIME COMMAND
 
 # So let’s say we wanted to sort by %MEM
-ps –aux | sort –k 4 –n –r | head -10
+ps -aux | sort -k 4 -n -r | head -10
 ```
 
 Read man to see why that works. Why do you suppose that it needs to be reversed
@@ -289,7 +289,7 @@ date
 date > datefile
 # redirects and creates a file datefile with the value
 
-date | tee –a datefile
+date | tee -a datefile
 # will come to screen, redirect to the file.
 ```
 
@@ -373,7 +373,7 @@ Permissions have to do with who can or cannot access (read), edit (write), or ex
 Permissions look like this.
 
 ```bash
-ls –l
+ls -l
 ```
 
 | Permission  | # of Links | UID Owner | Group Owner | Size (b) | Creation Month | Creation Day | Creation Time | File Name |

--- a/src/u2lab.md
+++ b/src/u2lab.md
@@ -57,8 +57,7 @@ ls
 # Can you see your newest files? Why or why not? (man ls)
 # What was the command to let you see those hidden files?
 
-l
-s –l
+ls -l
 # What do you know about this long listing? Think about 10 things this can show you.
 # Did it show you all the files or are some missing?
 ```
@@ -80,7 +79,7 @@ cat /etc/*release
 
 uname
 uname -a
-uname –r
+uname -r
 
 # man uname to see what those options mean if you don’t recognize the values
 ```
@@ -90,7 +89,7 @@ uname –r
 ```bash
 cat /proc/meminfo
 free
-free –m
+free -m
 
 # What do each of these commands show you? How are they useful?
 ```
@@ -101,7 +100,7 @@ free –m
 cat /proc/cpuinfo
 # What type of processors do you have? How many are there? (counting starts at 0)
 
-cat /proc/cpuinfo | grep proc | wc –l
+cat /proc/cpuinfo | grep proc | wc -l
 # Does this command accurately count the processors?
 ```
 
@@ -112,11 +111,11 @@ df
 # But df is barely readable, so find the option that makes it more readable `man df`
 
 df -h
-df -h | grep –i var
+df -h | grep -i var
 # What does this show, or search for? Can you invert this search? (hint `man grep`
 # look for invert or google “inverting grep’s output”)
 
-df –h | grep –i sd
+df -h | grep -i sd
 # This one is a little harder, what does this one show? Not just the line, what are
 # we checking for? (hint if you need it, google “what is /dev/sda in linux”)
 
@@ -125,25 +124,25 @@ mount
 # you to verify that the mount is there for /home on a system. Can you check that
 # quickly with one command?
 
-mount | grep –i home
+mount | grep -i home
 #This works, but there is a slight note to add here. Just because something isn’t
 # individually mounted doesn’t mean it doesn’t exist. It just means it’s not part of
 # it’s own mounted filesystem.
 
-mount | grep –i /home/xgqa6cha
+mount | grep -i /home/xgqa6cha
 # will produce no output
 
-df –h /home/xgqa6cha
+df -h /home/xgqa6cha
 # will show you that my home filesystem falls under /home.
 
 cd ~; pwd; df -h .
 # This command moves you to your home directory, prints out that directory,
 # and then shows you what partition your home directory is on.
 
-du –sh .
+du -sh .
 # will show you space usage of just your directory
 
-try `du –h .` as well to see how that ouput differs
+try `du -h .` as well to see how that ouput differs
 # read `man du` to learn more about your options.
 ```
 
@@ -179,7 +178,7 @@ whoami
 printenv
 # This scrolls by way too fast, how would you search for your home?
 
-printenv | grep –i home
+printenv | grep -i home
 whoami
 id
 echo $SHELL
@@ -188,18 +187,18 @@ echo $SHELL
 #### Check running processes and services:
 
 ```bash
-ps –aux | more
-ps –ef | more
-ps –ef | wc –l
+ps -aux | more
+ps -ef | more
+ps -ef | wc -l
 ```
 
 #### Check memory usage and what is using the memory:
 
 ```bash
 # Run each of these individually for understanding before we look at part b.
-free –m
-free –m | egrep “Mem|Swap”
-free –m| egrep “Mem|Swap” | awk ‘{print $1, $2, $3}’
+free -m
+free -m | egrep “Mem|Swap”
+free -m| egrep “Mem|Swap” | awk ‘{print $1, $2, $3}’
 free -t | egrep "Mem|Swap" | awk '{print $1 " Used Space = " ($3 / $2) * 100"%"}'
 
 # Taking this apart a bit:

--- a/src/u3lab.md
+++ b/src/u3lab.md
@@ -44,7 +44,7 @@ Echo “this is a string of text” >> somefile
 # Repeat 3 times
 cat somefile
 # How many lines are there?
-cheat with `cat somefile | wc –l`
+cheat with `cat somefile | wc -l`
 echo “this is our other test text” >> somefile
 # Repeat 3 times
 cat somefile | nl

--- a/src/u4lab.md
+++ b/src/u4lab.md
@@ -38,11 +38,11 @@ The lab has been provided for convenience below:
 6. `cd unit4`
 7. `ps`
    - Read `man ps`
-8. `ps –ef`
+8. `ps -ef`
    - What does this show differently?
-9. `ps –ef | grep –i root`
+9. `ps -ef | grep -i root`
    - What is the PID of the 4th line?
-10. `ps –ef | grep –i root | wc –l`
+10. `ps -ef | grep -i root | wc -l`
     - What does this show you and why might it be useful?
 11. `top`
     - Use `q` to exit.
@@ -53,7 +53,7 @@ The lab has been provided for convenience below:
 1. Real quick check for a package that is useful.
 
    ```bash
-   rpm –qa | grep –i iostat #should find nothing
+   rpm -qa | grep -i iostat #should find nothing
    ```
 
 2. Let's find what provides iostat by looking in the YUM (we'll explore more in later lab)
@@ -67,7 +67,7 @@ The lab has been provided for convenience below:
 3. Let's check to see if we have it
 
    ```bash
-   rpm –qa | grep –i sysstat
+   rpm -qa | grep -i sysstat
    ```
 
 4. If you don't, lets install it
@@ -78,14 +78,14 @@ The lab has been provided for convenience below:
 
 5. Re-check to verify we have it now
    ```bash
-   rpm –qa | grep –I sysstat
-   rpm –qi sysstat<version>
+   rpm -qa | grep -I sysstat
+   rpm -qi sysstat<version>
    iostat # We'll look at this more in a bit
    ```
    While we're working with packages, make sure that Vim is on your system.  
    This is the same procedure as above.
    ```bash
-   rpm –qa | grep –i vim  # Check if vim is installed
+   rpm -qa | grep -i vim  # Check if vim is installed
    # If it's there, good.
    dnf install vim
    # If it's not, install it so you can use vimtutor later (if you need help with vi commands)
@@ -101,7 +101,7 @@ The lab has been provided for convenience below:
    cat /etc/*release
    uname
    uname -a
-   uname –r
+   uname -r
    ```
 
    Run `man uname` to see what those options mean if you don't recognize the values
@@ -113,7 +113,7 @@ The lab has been provided for convenience below:
    What is your kernel number? Highlight it (copy in putty)
 
    ```bash
-   rpm –qi <kernel from earlier>
+   rpm -qi <kernel from earlier>
    ```
 
    What does this tell you about your kernel?
@@ -144,9 +144,9 @@ pvs # What system are we running if we have physical volumes?
 
 - Check some quick disk statistics
   ```bash
-  iostat –d
-  iostat –d 2   # Wait for a while, then use crtl + c to break. What did this do? Try changing this to a different number.
-  iostat –d 2 5 # Don't break this, just wait. What did this do differently? Why might this be useful?
+  iostat -d
+  iostat -d 2   # Wait for a while, then use crtl + c to break. What did this do? Try changing this to a different number.
+  iostat -d 2 5 # Don't break this, just wait. What did this do differently? Why might this be useful?
   ```
 
 3. Check the amount of RAM
@@ -154,7 +154,7 @@ pvs # What system are we running if we have physical volumes?
    ```bash
    cat /proc/meminfo
    free
-   free –m
+   free -m
    ```
 
    - What do each of these commands show you? How are they useful?
@@ -167,15 +167,15 @@ pvs # What system are we running if we have physical volumes?
    Look at the flags. Sometimes when compiling these are important to know. This is how
    you check what execution flags your processor works with.
    ```bash
-   cat /proc/cpuinfo | grep proc | wc –l
+   cat /proc/cpuinfo | grep proc | wc -l
    ```
    - Does this command accurately count the processors?
    - Check some quick processor statistics
 
 ```bash
-iostat –c
-iostat –c 2 # Wait for a while, then use Ctrl+C to break. What did this do? Try changing this to a different number.
-iostat –c 2 5 # Don't break this, just wait. What did this do differently? Why might this be useful?
+iostat -c
+iostat -c 2 # Wait for a while, then use Ctrl+C to break. What did this do? Try changing this to a different number.
+iostat -c 2 5 # Don't break this, just wait. What did this do differently? Why might this be useful?
 ```
 
 Does this look familiar to what we did earlier with `iostat`?
@@ -214,9 +214,9 @@ Does this look familiar to what we did earlier with `iostat`?
 7. Check running processes and services
 
    ```bash
-   ps –aux | more
-   ps –ef | more
-   ps –ef | wc –l
+   ps -aux | more
+   ps -ef | more
+   ps -ef | wc -l
    ```
 
    - Try to use what you've learned to see all the processes owned by your user
@@ -229,7 +229,7 @@ Does this look familiar to what we did earlier with `iostat`?
      ```
    - Check memory for the last day
      ```bash
-     sar –r | more
+     sar -r | more
      ```
 
 Sar is a tool that shows the 10 minute weighted average of the system for the last day.
@@ -249,8 +249,8 @@ You may have guessed that sar runs almost exactly like `iostat`.
   sar 2  # Ctrl+C to break
   sar 2 5
   # or
-  sar –r 2
-  sar –r 2 5
+  sar -r 2
+  sar -r 2 5
   ```
 
 - Check sar logs for previous daily usage
@@ -258,8 +258,8 @@ You may have guessed that sar runs almost exactly like `iostat`.
   cd /var/log/sa/
   ls
   # Sar logfiles will look like: sa01 sa02 sa03 sa04 sa05 sar01 sar02 sar03 sar04
-  sar –f sa03 | head
-  sar –r –f sa03 | head #should output just the beginning of 3 July (whatever month you're in).
+  sar -f sa03 | head
+  sar -r -f sa03 | head #should output just the beginning of 3 July (whatever month you're in).
   ```
   Most Sar data is kept for just one month but is very configurable.
   Read `man sar` for more info.
@@ -299,8 +299,8 @@ You could do something like this:
 - Let's verify that file is as long as we expect it to be:
 
   ```bash
-  ls –l /tmp/sar_data*
-  cat /tmp/sar_data_<yourhostname> | wc –l
+  ls -l /tmp/sar_data*
+  cat /tmp/sar_data_<yourhostname> | wc -l
   ```
 
 - Is it what you expected? You can also visually check it a number of ways
@@ -314,7 +314,7 @@ You could do something like this:
 Your system is running the cron daemon. You can check with:
 
 ```bash
-ps –ef | grep –i cron
+ps -ef | grep -i cron
 systemctl status crond
 ```
 

--- a/src/u5lab.md
+++ b/src/u5lab.md
@@ -41,7 +41,7 @@ Exercises (Warmup to quickly run through your system and practice commands)
 6. `cat /etc/passwd | tail -5 | awk -F : ‘{print $1, $3, $7}'`
    - What did that do and what do each of the `$#` represent?
    - Can you give the 2nd, 5th, and 6th fields?
-7. `cat /etc/passwd | tail -5 | awk –F : ‘{print $NF}'`
+7. `cat /etc/passwd | tail -5 | awk -F : ‘{print $NF}'`
    - What does this `$NF` mean? Why might this be useful to us as administrators?
 8. `alias`
    - Look at the things you have aliased.
@@ -100,7 +100,7 @@ how they secure the system. The four files are `/etc/passwd`, `/etc/group`, `/et
    Check the file permissions:
 
    ```bash
-   ls –l /etc/passwd
+   ls -l /etc/passwd
    ```
 
    Do this for each file to see how their permissions are set.
@@ -156,7 +156,7 @@ work
 
    ```bash
    tail -5 /etc/passwd
-   tail –5 /etc/shadow
+   tail -5 /etc/shadow
    ```
 
    What `UID` and `GID` were each of these given? Do they match up?
@@ -242,7 +242,7 @@ work
    This isn't required, but can save you headache in the future.
 
    ```bash
-   groupadd –g 60001 project
+   groupadd -g 60001 project
    tail -5 /etc/group
    ```
 
@@ -267,8 +267,8 @@ work
    So maybe now we need to move our users into that group.
 
    ```bash
-   usermod –G project user4
-   tail –f /etc/group # Should see user4 in the group
+   usermod -G project user4
+   tail -f /etc/group # Should see user4 in the group
    ```
 
    But, maybe we want to add more users and we want to just put them in there:
@@ -299,10 +299,10 @@ work
 
    ```bash
    mkdir /project
-   ls –ld /project
+   ls -ld /project
    chown root:project /project
    cmod 775 /project
-   ls –ld /project
+   ls -ld /project
    ```
 
    If you do this, you now have a directory `/project` and you've changed the group ownership to `/project`.
@@ -350,7 +350,7 @@ Permissions have to do with who can or cannot access (read), edit (write), or ex
 Permissions look like this:
 
 ```bash
-ls –l
+ls -l
 ```
 
 |  Permission   | # of Links | UID Owner |  Group Owner   | Size (b) | Creation Month | Creation Day | Creation Time | Name of File |

--- a/src/u7lab.md
+++ b/src/u7lab.md
@@ -75,7 +75,7 @@ examples.
 
 ```bash
 # Check to see if you have bc tool.
-rpm –q bc
+rpm -q bc
 
 #Install it if you need to
 dnf install bc
@@ -123,7 +123,7 @@ rpm -qi systemd
 rpm -q systemd
 
 # query all packages on the system (is better used with | more or | grep)
-rpm –qa
+rpm -qa
 
 #for example shows all kernels and kernel tools
 rpm -qa | grep -i kernel
@@ -260,7 +260,7 @@ similar environments, so you go to install it on their system for them.
 
 ```bash
 # See if we already have a version.
-rpm –qa mariadb
+rpm -qa mariadb
 
 # See if dnf knows about it
 dnf search mariadb
@@ -295,11 +295,11 @@ dnf remove mariadb
 # hit “N”
 
 # this removes mariadb from your system
-dnf –y remove mariadb
+dnf -y remove mariadb
 
 # But did this remove those dependencies from earlier?
-rpm –q {dependency}
-rpm –qi {dependency}
+rpm -q {dependency}
+rpm -qi {dependency}
 
 # How are you going to remove that if it’s still there?
 # Checking where something came from. What package provides something in your system

--- a/src/u8lab.md
+++ b/src/u8lab.md
@@ -44,7 +44,7 @@ Review how to use vi, if you have a problem getting out or saving your file or u
 
 ```bash
 # Let us locate and inspect the GNU C Compiler Package
-rpm –qa | grep –i gcc
+rpm -qa | grep -i gcc
 dnf whatprovides gcc
 dnf search gcc
 Check out all the options of different compilers
@@ -93,9 +93,9 @@ gcc a.c
 #If there is an error, does it still work?
 
 #Alternatively, and more correctly, use this:
-gcc –o firstprogram a.c
+gcc -o firstprogram a.c
 #Which will create an executable file called first program
-ls –salh
+ls -salh
 #Will show you all your files. Note how big those compiled programs are.
 #Execute your programs
 ./a.out


### PR DESCRIPTION
Copying code blocks from the word docs were causing malformed special characters to sneak into code block commands in the markdown files.

Tried to find as many as I could