### PR TITLE
feat: Add .gitattributes to automatically convert line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
This should solve the problem of the CR control characters (`^M`) ending up in our editors on Linux.