### PR TITLE
feat: Update resource gen script to contain unit titles based on unitindex

### DIFF
--- a/scripts/en-dash-conversion
+++ b/scripts/en-dash-conversion
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# 's/–/-/g' 
-declare -a FILES
-read -r -a FILES -d '' < <(find ../src/ -name 'u*' -type f)
-# printf "File: %s\n" "${FILES[@]}"
-sed -i 's/–/-/g' "${FILES[*]}"
-

--- a/scripts/en-dash-conversion
+++ b/scripts/en-dash-conversion
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# 's/–/-/g' 
+declare -a FILES
+read -r -a FILES -d '' < <(find ../src/ -name 'u*' -type f)
+# printf "File: %s\n" "${FILES[@]}"
+sed -i 's/–/-/g' "${FILES[*]}"
+

--- a/scripts/generate_resources.sh
+++ b/scripts/generate_resources.sh
@@ -82,8 +82,16 @@ pull-links() {
     done
 
     TOTAL_LINK_COUNT=$(( COUNT_MD_LINKS + COUNT_UF_LINKS + COUNT_REG_LINKS ))
-    printf "\nREPORT:\n- Markdown Links\t%s\n- Regular Links\t\t%s\n- Unformatted Links\t%s\n\nTotal Links: %s\n" "$COUNT_MD_LINKS" "$COUNT_REG_LINKS" "$COUNT_UF_LINKS" "$TOTAL_LINK_COUNT"
-    printf 'Duplicates: %s\n' "$DUPLICATES"
+    cat <<- EOF
+	REPORT:
+	- Markdown Links        $COUNT_MD_LINKS
+	- Regular Links         $COUNT_REG_LINKS
+	- Unformatted Links     $COUNT_UF_LINKS
+	Total Links: $TOTAL_LINK_COUNT
+	Total links added: ${#ADDED_LINKS[@]}
+	
+	Duplicates: $DUPLICATES
+	EOF
 
 }
 

--- a/src/resources.md
+++ b/src/resources.md
@@ -5,59 +5,7 @@
     </p>
 </div>
 
-Running list of all links, may need further categorization at a later date.
+This file is dynamically generated at build time using GitHub Actions.  
 
-| Description                                              | Link                                                                                                                                                             |
-| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| LAC Youtube Playlist                                     | <https://www.youtube.com/watch?v=eHB8WKWz2eQ&list=PLyuZ_vuAWmprPIqsG11yoUG49Z5dE5TDu>                                                                            |
-| What is Vim?                                             | <https://github.com/vim/vim>                                                                                                                                     |
-| The Linux Foundation                                     | <https://www.linux.org/pages/download/>                                                                                                                          |
-| Linux CLI Cheatsheets                                    | <https://www.digitalocean.com/community/tutorials/linux-commands>                                                                                                |
-| Vim Adventures                                           | <https://vim-adventures.com/>                                                                                                                                    |
-| Vim Instructional Video                                  | <https://www.youtube.com/watch?v=d8XtNXutVto>                                                                                                                    |
-| Cron Wiki Page                                           | <https://en.wikipedia.org/wiki/Cron>                                                                                                                             |
-| Git                                                      | <https://git-scm.com/>                                                                                                                                           |
-| Fireship's How to use Git and Github (12m)               | <https://youtu.be/HkdAHXoRtos>                                                                                                                                   |
-| freeCodeCamp's Git and GitHub Crash Course (1hr)         | <https://youtu.be/RGOj5yH7evk>                                                                                                                                   |
-| Git Rebasing documentation                               | <https://git-scm.com/book/en/v2/Git-Branching-Rebasing>                                                                                                          |
-| Google SRE Book - Implementing SLOs                      | <https://sre.google/workbook/implementing-slos/>                                                                                                                 |
-| AWS High Availability Architecture Guide                 | <https://docs.aws.amazon.com/pdfs/whitepapers/latest/real-time-communication-on-aws/real-time-communication-on-aws.pdf>                                          |
-| Red Hat High Availability Cluster Configuration          | <https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_high_availability_clusters/index>                        |
-| Building Secure and Reliable Systems: Crisis Management  | <https://google.github.io/building-secure-and-reliable-systems/raw/ch17.html>                                                                                    |
-| Building Secure and Reliable Systems: Operation Security | <https://google.github.io/building-secure-and-reliable-systems/raw/ch17.html#operational_security>                                                               |
-| AWS Real-Time Communication Whitepaper                   | <https://docs.aws.amazon.com/pdfs/whitepapers/latest/real-time-communication-on-aws/real-time-communication-on-aws.pdf#high-availability-and-scalability-on-aws> |
-| Implementing SLOs                                        | <https://sre.google/workbook/implementing-slos/>                                                                                                                 |
-| OWASP Top Ten                                            | <https://owasp.org/www-project-top-ten/>                                                                                                                         |
-| Attack Vectors                                           | <https://www.cobalt.io/blog/defending-against-23-common-attack-vectors>                                                                                          |
-| mitre.org                                                | <https://attack.mitre.org/>                                                                                                                                      |
-| OWASP Top Ten                                            | <https://owasp.org/www-project-top-ten/>                                                                                                                         |
-| Common Attack Vectors                                    | <https://www.cobalt.io/blog/defending-against-23-common-attack-vectors>                                                                                          |
-| Operations Bridge                                        | <https://cio-wiki.org/wiki/Operations_Bridge>                                                                                                                    |
-| Security Incident Cheatsheet                             | <https://zeltser.com/media/docs/security-incident-survey-cheat-sheet.pdf?msc=Cheat+Sheet+Blog>                                                                   |
-| Battle Drills                                            | <https://en.wikipedia.org/wiki/Battle_drill>                                                                                                                     |
-| Operations Bridges                                       | <https://cio-wiki.org/wiki/Operations_Bridge>                                                                                                                    |
-| Security Incident Cheat Sheet                            | <https://zeltser.com/media/docs/security-incident-survey-cheat-sheet.pdf?msc=Cheat+Sheet+Blog>                                                                   |
-| Battle Drill                                             | <https://en.wikipedia.org/wiki/Battle_drill>                                                                                                                     |
-| Tmux Wiki                                                | <https://github.com/tmux/tmux/wiki>                                                                                                                              |
-| Tmux Cheatsheet                                          | <https://tmuxcheatsheet.com/>                                                                                                                                    |
-| GNU Screen Site                                          | <https://www.gnu.org/software/screen/>                                                                                                                           |
-| GNU Screen Manual                                        | <https://www.gnu.org/software/screen/manual/screen.html>                                                                                                         |
-| Zellij Site                                              | <https://zellij.dev/>                                                                                                                                            |
-| Link to Killercoda                                       | <https://killercoda.com/>                                                                                                                                        |
-| RedHat: User and Group Management                        | <https://www.redhat.com/en/blog/linux-user-group-management>                                                                                                     |
-| Rocky Linux User Admin Guide                             | <https://docs.rockylinux.org/books/admin_guide/06-users/>                                                                                                        |
-| Killercoda lab by FishermanGuyBro                        | <https://killercoda.com/fishermanguybro>                                                                                                                         |
-| Official Firewalld Documentation                         | <https://firewalld.org/documentation/>                                                                                                                           |
-| Official UFW Documentation                               | <https://help.ubuntu.com/community/UFW>                                                                                                                          |
-| Wikipedia entry for Next-Gen Firewalls                   | <https://en.wikipedia.org/wiki/Next-generation_firewall>                                                                                                         |
-| DNF package manager                                      | <https://en.wikipedia.org/wiki/DNF_(software)>                                                                                                                   |
-| RedHat Docs: DNF                                         | <https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/managing_software_with_the_dnf_tool/index>                                      |
-| RedHat Docs: Repositories/RHEL 8                         | <https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/considerations_in_adopting_rhel_8/repositories_considerations-in-adopting-rhel-8>      |
-| Yellow Dog Linux Wiki                                    | <https://en.wikipedia.org/wiki/Yellow_Dog_Linux>                                                                                                                 |
-| Git Pages workflow                                       | <https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages>                                                    |
-| Getting Started with Ansible                             | <https://docs.ansible.com/ansible/latest/getting_started/index.html>                                                                                             |
-| Dockerfile Reference Page                                | <https://docs.docker.com/reference/dockerfile/>                                                                                                                  |
-| Podman Command List                                      | <https://docs.podman.io/en/latest/Commands.html>                                                                                                                 |
-| TBD                                                      | TBD                                                                                                                                                              |
-| TBD                                                      | TBD                                                                                                                                                              |
-| TBD                                                      | TBD                                                                                                                                                              |
+To see what it looks like, run `./scripts/generate_resources.sh` from the **root
+directory** of the project (e.g., `cd ~/lac && ./scripts/generate_resources.sh`).  


### PR DESCRIPTION
I made an update to the resource generation script to read the unit numbers and their corresponding titles from `unitindex.md` using perl. So each unit on the final `resources.md` page will contain the titles as well.  

If `unitindex.md` changes format, this could cause some issues. If the file is renamed or deleted, it will go back to using just the unit numbers.  

I also switched to perl regex from `sed` for certain tasks -- some of the links were displaying more text than they should have. Since `sed` doesn't support non-greedy quantifiers, there is no easy way to go about making sure it doesn't pull all text to the last parenthesis when grabbing markdown links.  

I also changed the contents of `resources.md` to reflect the fact that it's auto-generated. This is just so that if someone makes changes to it, they won't wonder why it's not doing anything when merged.  