### PR TITLE
fix: ansible dnf deploy cargo/mdbook install issues

### DIFF
--- a/src/assets/deploy/ansible-playbook.yml
+++ b/src/assets/deploy/ansible-playbook.yml
@@ -26,10 +26,12 @@
             enabled: true
 
         - name: DNF - Installing mdbook
-          community.general.cargo:
-            name: mdbook
-            locked: true
-            state: present
+          ansible.builtin.command:
+            argv:
+              - /usr/bin/cargo
+              - install
+              - --locked
+              - mdbook@0.4.48
 
     - name: Build ProLUG website LAC for APT systems
       when: ansible_pkg_mgr == "apt"


### PR DESCRIPTION
Ansible cargo community module is not immune to rust cargo install issues. Tested in a Rocky 9.5 container