### PR TITLE
refactor(action/binary): binary fetch and validation changes

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -46,10 +46,7 @@ jobs:
 
       - name: Fetch mdBook binary from mdBook repository if not cached
         if: steps.cache-mdbook.outputs.cache-hit != 'true'
-        run: |
-          curl -sLO "https://github.com/rust-lang/mdBook/releases/download/${MDBOOK_VERSION}/mdbook-${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-          tar xfz mdbook-${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz
-          rm -f mdbook-${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz
+        run: bash ./scripts/binary-validation.sh ${MDBOOK_VERSION}
 
       - name: Setup Pages
         id: pages

--- a/scripts/binary-validation.sh
+++ b/scripts/binary-validation.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# Targeting mdBook version v0.4.52 as of Aug, 2025
+# Only requests 5 latest release records, remove ?per_page=5 to fetch all
+# Requires mdBook semantic version input from command line
+# For example 'binary-validation.sh v0.1.15'
+
+set -euo pipefail
+
+MDBOOK_VERSION=$1
+declare reg_pattern="^v([[:digit:]]+\.){2}[[:digit:]]+$"
+API_ARRAY=$(mktemp)
+declare JSON
+
+json_setup() {
+
+	local JQUERY="
+	map(select(.tag_name==\"${MDBOOK_VERSION}\"))
+	| .[].assets
+	| map(select(.name==\"mdbook-${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz\"))
+	"
+	printf "mdBook Binary script executing..."
+	printf "\nQuerying GH API for JSON %s mdBook record..." "${MDBOOK_VERSION}"
+
+	curl -sL \
+		-H "Accept: application/vnd.github+json" \
+		-H "X-GitHub-Api-Version: 2022-11-28" \
+		https://api.github.com/repos/rust-lang/mdBook/releases?per_page=5 \
+		>"${API_ARRAY}" ||
+		{
+			printf "\nSomething went wrong with the GH API request."
+			exit 1
+		} 1>&2
+
+	JSON="$(jq "${JQUERY}" "${API_ARRAY}")" ||
+		{
+			printf "\nEncountered error processing JSON, version may not exist. Dumping GH API JSON record if present:\n%s" "${JSON}"
+			exit 1
+		} 1>&2
+}
+
+api_fetch() {
+
+	local DL_URL
+	local API_DIGEST
+	local ZIP
+	local ZIP_DIGEST
+
+	if [[ -n "${JSON}" ]]; then
+		printf "\nParsing API JSON return data and assigning variables...\n\n"
+
+		DL_URL="$(jq -r '.[].browser_download_url' <<<"${JSON}")"
+		API_DIGEST="$(jq -r '.[].digest' <<<"${JSON}" | cut -d: -f2)"
+		ZIP="$(jq -r '.[].name' <<<"${JSON}")"
+
+		printf "%3s %s\n" "URL:" "${DL_URL}" "API_DIGEST:" "${API_DIGEST}" "ZIP:" "${ZIP}"
+		printf "\nFetching binary...\nCalculating ZIP digest...\n\n"
+
+		curl -LO --progress-bar "$DL_URL"
+		ZIP_DIGEST=$(sha256sum "${PWD}/${ZIP}" | awk '{print $1}')
+
+		printf "\nZIP_DIGEST: %s\n" "${ZIP_DIGEST}"
+
+		if [[ "${API_DIGEST}" = "${ZIP_DIGEST}" ]]; then
+			printf "\nDigest check succeeded!\nCleaning up...\nmdBook binary unzipped and ready for execution!"
+			tar xfz "${ZIP}" && rm -f "${ZIP}"
+			exit 0
+		else
+			printf "\nThe API digest appears to be different than the downloaded binary digest:"
+			printf "%2s %s\n" "API sha:" "${API_DIGEST}" "ZIP sha:" "${ZIP_DIGEST}"
+			printf "\nDumping JSON record and cleaning up...\n\n"
+			cat "${JSON}" && rm -f "${ZIP}"
+			exit 1
+		fi
+
+	else
+		printf "\nThe processed JSON record appears to be empty, queried version may not exist...\nExiting..."
+		exit 1
+	fi
+}
+
+if [[ $1 =~ ${reg_pattern} && -n $1 ]]; then
+
+	json_setup
+	api_fetch
+
+else
+	printf "This script requires an mdBook version as an argument and to observe mdBook's semantic versioning, for example 'binary-validation.sh v0.4.20'"
+	exit 1
+fi


### PR DESCRIPTION
- Refactor pulling mdBook binary from the GitHub API instead of manual parse. 
- Designed to implement and input the MDBOOK_VERSION variable within runner environment.
- Attempts to provide verbose output if things go wrong. 
- Cleans up as best as it can.

I did not test this against my fork. Here's hoping it works 🤞😏

Possible TODO:
- Implement GH token

Edit:
Just found out the sha digest is a new [feature of the API](https://github.blog/changelog/2025-06-03-releases-now-expose-digests-for-release-assets/)... So this script in its current state will only work for versions of mdBook v0.4.52+ since that is the most recent release that is affected by this change. 🤣